### PR TITLE
Add openssh-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN build_deps="curl" && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${build_deps} ca-certificates && \
     curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git-lfs && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git-lfs openssh-client && \
     git lfs install && \
     rm -r /var/lib/apt/lists/*
 


### PR DESCRIPTION
When executing git clone through ssh protocol, it's necessary to have the ssh client.